### PR TITLE
Python 3.4 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ var/
 *.manifest
 *.spec
 
+#pyenv
+.python-version
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,380 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# DEPRECATED
+include-ids=no
+
+# DEPRECATED
+symbols=no
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#disable=
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=stringprep,optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/parserator/main.py
+++ b/parserator/main.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
 from argparse import ArgumentParser
-import manual_labeling
-import training
+from . import manual_labeling
+from . import training
 import os
 import shutil
 import fileinput
-from parser_template import init_template, setup_template, test_tokenize_template
+from .parser_template import init_template, setup_template, test_tokenize_template
 
 
 def dispatch():
@@ -39,7 +41,7 @@ def label(args) :
         outfile_path = args.outfile
         manual_labeling.label(module, infile_path, outfile_path)
     else:
-        print 'Please specify an input csv file [--infile FILE] and an output xml file [--outfile FILE]'
+        print('Please specify an input csv file [--infile FILE] and an output xml file [--outfile FILE]')
 
 
 def train(args) :
@@ -49,7 +51,7 @@ def train(args) :
         
         training.train(module, train_file_list)
     else:
-        print 'Please specify one or more xml training files (comma separated) [--trainfile FILE]'
+        print('Please specify one or more xml training files (comma separated) [--trainfile FILE]')
 
 
 def init(args) :
@@ -60,37 +62,37 @@ def init(args) :
     
     dirs_to_mk = [name, data, training, tests]
 
-    print '\nInitializing directories for %s' %name
+    print('\nInitializing directories for %s' %name)
     for directory in dirs_to_mk:
         if not os.path.exists(directory):
             os.mkdir(directory)
-            print '* %s' %directory
+            print('* %s' %directory)
 
-    print '\nGenerating __init__.py'
+    print('\nGenerating __init__.py')
     init_path = name + '/__init__.py'
 
     if os.path.exists(init_path):
-        print '  warning: %s already exists' %init_path
+        print('  warning: %s already exists' %init_path)
     else:
         with open(init_path, "w") as f:
             f.write(init_template())
-        print '* %s' %init_path
+        print('* %s' %init_path)
 
-    print '\nGenerating setup.py'
+    print('\nGenerating setup.py')
     if os.path.exists('setup.py'):
-        print '  warning: setup.py already exists'
+        print('  warning: setup.py already exists')
     else:
         with open('setup.py', 'w') as f:
             f.write(setup_template(name))
-        print '* setup.py'
+        print('* setup.py')
 
-    print '\nGenerating test file'
+    print('\nGenerating test file')
     token_test_path = tests+'/test_tokenizing.py'
     if os.path.exists(token_test_path):
-        print '  warning: %s already exists' %token_test_path
+        print('  warning: %s already exists' %token_test_path)
     else:
         with open(token_test_path, 'w') as f:
             f.write(test_tokenize_template(name))
-        print '* %s' %token_test_path
+        print('* %s' %token_test_path)
 
 

--- a/parserator/manual_labeling.py
+++ b/parserator/manual_labeling.py
@@ -1,7 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import zip
+from builtins import str
+from builtins import range
 from lxml import etree
 import sys
 import os.path
-import data_prep_utils
+from . import data_prep_utils
 import re
 import csv
 from argparse import ArgumentParser
@@ -9,12 +14,12 @@ import unidecode
 
 
 def consoleLabel(raw_strings, labels, module): 
-    print '\nStart console labeling!\n'
-    print 'These are the tags available for labeling:'
+    print('\nStart console labeling!\n')
+    print('These are the tags available for labeling:')
     valid_input_tags = dict((str(i), label) for i, label in enumerate(labels))
     for i in range(len(labels)):
-        print '%s : %s' %(i, valid_input_tags[str(i)])
-    print '\n\n'
+        print('%s : %s' %(i, valid_input_tags[str(i)]))
+    print('\n\n')
     valid_responses = ['y', 'n', 's', 'f', '']
     finished = False
 
@@ -26,9 +31,9 @@ def consoleLabel(raw_strings, labels, module):
 
         if not finished:
 
-            print '(%s of %s)' % (i, total_strings)
-            print '-'*50
-            print 'STRING: %s' %raw_sequence
+            print('(%s of %s)' % (i, total_strings))
+            print('-'*50)
+            print('STRING: %s' %raw_sequence)
             
             preds = module.parse(raw_sequence)
 
@@ -53,19 +58,19 @@ def consoleLabel(raw_strings, labels, module):
 
 
                 elif user_input in ('' or 's') :
-                    print 'Skipped\n'
+                    print('Skipped\n')
                 elif user_input == 'f':
                     finished = True
 
-    print 'Done! Yay!'
+    print('Done! Yay!')
     return tagged_strings, strings_left_to_tag
 
 
 def print_table(table):
     col_width = [max(len(x) for x in col) for col in zip(*table)]
     for line in table:
-        print "| %s |" % " | ".join("{:{}}".format(x, col_width[i])
-                                for i, x in enumerate(line))
+        print("| %s |" % " | ".join("{:{}}".format(x, col_width[i])
+                                for i, x in enumerate(line)))
         
 
 def manualTagging(preds, labels):
@@ -73,7 +78,7 @@ def manualTagging(preds, labels):
     tagged_sequence = []
     for token, predicted_tag in preds:
         while True:
-            print 'What is \'%s\' ? If %s hit return' % (token, predicted_tag)
+            print('What is \'%s\' ? If %s hit return' % (token, predicted_tag))
             user_choice = sys.stdin.readline().strip()
             if user_choice == '' :
                 tag = predicted_tag
@@ -82,12 +87,12 @@ def manualTagging(preds, labels):
                 tag = label_options[user_choice]
                 break
             elif user_choice == '?' :
-                print 'These are the valid inputs:'
-                for item in sorted(label_options.items(), 
+                print('These are the valid inputs:')
+                for item in sorted(list(label_options.items()), 
                                    key=lambda x : int(x[0])) :
-                    print '%s : %s' % (item)
+                    print('%s : %s' % (item))
             else:
-                print "That is not a valid tag. Type '?' to see the valid inputs"
+                print("That is not a valid tag. Type '?' to see the valid inputs")
 
         tagged_sequence.append((token, tag))
     return tagged_sequence
@@ -95,12 +100,12 @@ def manualTagging(preds, labels):
 
 def naiveConsoleLabel(raw_strings, labels, module): 
 
-    print '\nStart console labeling!\n'
-    print 'These are the tags available for labeling:'
+    print('\nStart console labeling!\n')
+    print('These are the tags available for labeling:')
     valid_input_tags = dict((str(i), label) for i, label in enumerate(labels))
     for i in range(len(labels)):
-        print '%s : %s' %(i, valid_input_tags[str(i)])
-    print '\n\n'
+        print('%s : %s' %(i, valid_input_tags[str(i)]))
+    print('\n\n')
 
     valid_responses = ['t', 's', 'f', '']
     finished = False
@@ -112,9 +117,9 @@ def naiveConsoleLabel(raw_strings, labels, module):
     for i, raw_sequence in enumerate(raw_strings, 1):
         if not finished:
 
-            print '(%s of %s)' % (i, total_strings)
-            print '-'*50
-            print 'STRING: %s' %raw_sequence
+            print('(%s of %s)' % (i, total_strings))
+            print('-'*50)
+            print('STRING: %s' %raw_sequence)
             
             tokens = module.tokenize(raw_sequence)
 
@@ -130,11 +135,11 @@ def naiveConsoleLabel(raw_strings, labels, module):
                     strings_left_to_tag.remove(raw_sequence)
 
                 elif user_input == 's':
-                    print 'Skipped\n'
+                    print('Skipped\n')
                 elif user_input == 'f':
                     finished = True
 
-    print 'Done! Yay!'
+    print('Done! Yay!')
     return tagged_strings, strings_left_to_tag
 
 def naiveManualTag(raw_sequence, labels):
@@ -143,16 +148,16 @@ def naiveManualTag(raw_sequence, labels):
     for token in raw_sequence:
         valid_tag = False
         while not valid_tag:
-            print 'What is \'%s\' ?' %token
+            print('What is \'%s\' ?' %token)
             user_input_tag = sys.stdin.readline().strip()
             if user_input_tag in valid_input_tags:
                 valid_tag = True
             elif user_input_tag == 'help':
-                print 'These are the valid inputs:'
+                print('These are the valid inputs:')
                 for i in range(len(labels)):
-                    print '%s : %s' %(i, valid_input_tags[str(i)])
+                    print('%s : %s' %(i, valid_input_tags[str(i)]))
             else:
-                print "That is not a valid tag. Type 'help' to see the valid inputs"
+                print("That is not a valid tag. Type 'help' to see the valid inputs")
             
         token_label = labels[int(user_input_tag)]
         sequence_labels.append((token, token_label))

--- a/parserator/spotcheck.py
+++ b/parserator/spotcheck.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from builtins import zip
 import pycrfsuite
 
 def compareTaggers(model1, model2, string_list, module_name):
@@ -28,20 +30,20 @@ def compareTaggers(model1, model2, string_list, module_name):
 
             if tags1 != tags2:
                 count_discrepancies += 1
-                print '\n'
-                print "%s. %s" %(count_discrepancies, string)
+                print('\n')
+                print("%s. %s" %(count_discrepancies, string))
                 
-                print '-'*75
+                print('-'*75)
                 print_spaced('token', model1, model2)
-                print '-'*75
+                print('-'*75)
                 for token in zip(tokens, tags1, tags2):
                     print_spaced(token[0], token[1], token[2])
-    print "\n\n%s of %s strings were labeled differently"%(count_discrepancies, len(string_list))
+    print("\n\n%s of %s strings were labeled differently"%(count_discrepancies, len(string_list)))
 
 
 def print_spaced(s1, s2, s3):
     n = 25
-    print s1 + " "*(n-len(s1)) + s2 + " "*(n-len(s2)) + s3
+    print(s1 + " "*(n-len(s1)) + s2 + " "*(n-len(s2)) + s3)
 
 def validateTaggers(model1, model2, labeled_string_list, module_name):
 
@@ -63,35 +65,35 @@ def validateTaggers(model1, model2, labeled_string_list, module_name):
         if tokens:
             features = module.tokens2features(tokens)
 
-            _, tags_true = zip(*components)
+            _, tags_true = list(zip(*components))
             tags_true = list(tags_true)
             tags1 = tagger1.tag(features)
             tags2 = tagger2.tag(features)
 
             if (tags1 != tags_true) and (tags2 != tags_true):
-                print "\nSTRING: ", unlabeled_string
-                print "TRUE: ", tags_true
-                print "*%s: "%model1, tags1
-                print "*%s: "%model2, tags2
+                print("\nSTRING: ", unlabeled_string)
+                print("TRUE: ", tags_true)
+                print("*%s: "%model1, tags1)
+                print("*%s: "%model2, tags2)
                 wrong_count_both += 1
             elif (tags1 != tags_true):
-                print "\nSTRING: ", unlabeled_string
-                print "TRUE: ", tags_true
-                print "*%s: "%model1, tags1
-                print "%s: "%model2, tags2
+                print("\nSTRING: ", unlabeled_string)
+                print("TRUE: ", tags_true)
+                print("*%s: "%model1, tags1)
+                print("%s: "%model2, tags2)
                 wrong_count_1 += 1
             elif (tags2 != tags_true):
-                print "\nSTRING: ", unlabeled_string
-                print "TRUE: ", tags_true
-                print "%s: "%model1, tags1
-                print "*%s: "%model2, tags2
+                print("\nSTRING: ", unlabeled_string)
+                print("TRUE: ", tags_true)
+                print("%s: "%model1, tags1)
+                print("*%s: "%model2, tags2)
                 wrong_count_2 += 1
             else:
                 correct_count += 1
 
-    print "\n\nBOTH WRONG: ", wrong_count_both
-    print "%s WRONG: %s" %(model1, wrong_count_1)
-    print "%s WRONG: %s" %(model2, wrong_count_2)
-    print "BOTH CORRECT: ", correct_count
+    print("\n\nBOTH WRONG: ", wrong_count_both)
+    print("%s WRONG: %s" %(model1, wrong_count_1))
+    print("%s WRONG: %s" %(model2, wrong_count_2))
+    print("BOTH CORRECT: ", correct_count)
 
 

--- a/parserator/training.py
+++ b/parserator/training.py
@@ -1,9 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
+from builtins import zip
 import pycrfsuite
 import random
 import os
 from lxml import etree
 from imp import reload
-import data_prep_utils
+from . import data_prep_utils
 import re
 import time
 
@@ -15,7 +18,7 @@ def trainModel(training_data, module,
     Y = []
 
     for raw_string, components in training_data:
-        tokens, labels = zip(*components)
+        tokens, labels = list(zip(*components))
         X.append(module.tokens2features(tokens))
         Y.append(labels)
 
@@ -44,9 +47,9 @@ def readTrainingData( xml_infile_list, collection_tag ):
                 file_xml = data_prep_utils.stripFormatting(file_xml)
                 for component_etree in file_xml:
                     # etree components to string representations
-                    component_string_list.append(etree.tostring(component_etree))
+                    component_string_list.append(etree.tostring(component_etree).decode('utf-8')
         else:
-            print 'WARNING: %s does not exist' % xml_infile
+            print('WARNING: %s does not exist' % xml_infile)
     # get rid of duplicates in string representations
     component_string_list = list(set(component_string_list))
 
@@ -54,7 +57,7 @@ def readTrainingData( xml_infile_list, collection_tag ):
     for component_string in component_string_list:
         # convert string representation back to xml
         sequence_xml = etree.fromstring(component_string)
-        raw_text = etree.tostring(sequence_xml, method='text')
+        raw_text = etree.tostring(sequence_xml, method='text').decode('utf-8')
         sequence_components = []
         for component in list(sequence_xml):
             sequence_components.append([component.text, component.tag])
@@ -76,13 +79,13 @@ def train(module, train_file_list) :
 
     training_data = list(readTrainingData(train_file_list, module.GROUP_LABEL))
     if not training_data:
-        print 'ERROR: No training data found. Perhaps double check your training data filepaths?'
+        print('ERROR: No training data found. Perhaps double check your training data filepaths?')
         return
 
     model_path = module.__name__+'/'+module.MODEL_FILE
     renameModelFile(model_path)
 
-    print '\ntraining model on %s training examples from %s' %(len(training_data), train_file_list)
+    print('\ntraining model on {num} training examples from {file_list}'.format(num=len(training_data), file_list=train_file_list))
     trainModel(training_data, module)
 
-    print '\ndone training! model file created: %s' %model_path
+    print('\ndone training! model file created: {path}'.format(path=model_path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml==3.4.1
 nose==1.3.4
+Unidecode==0.4.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml==3.4.1
-nose==1.3.4
 Unidecode==0.4.17
+python-crfsuite>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+future==0.14.3
 lxml==3.4.1
 Unidecode==0.4.17
 python-crfsuite>=0.7

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,16 @@ try:
     from setuptools import setup
 except ImportError :
     raise ImportError("setuptools module required, please go to https://pypi.python.org/pypi/setuptools and follow the instructions for installing setuptools")
+from pip.req import parse_requirements
+
+# parse_requirements() returns generator of pip.req.InstallRequirement objects
+install_reqs = parse_requirements(<requirements_path>)
+
+# reqs is a list of requirement
+reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
-    version='0.2',
+    version='0.3',
     url='https://github.com/datamade/parserator',
     description='Create parsers',
     name='parserator',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Information Analysis'],

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ except ImportError :
 
 reqs = [
     'lxml==3.4.1',
-    'Unidecode==0.4.17',
-    'python-crfsuite>=0.7'
+    'python-crfsuite>=0.7',
+    'Unidecode==0.4.17'
 ]
 
 setup(
@@ -16,9 +16,7 @@ setup(
     name='parserator',
     packages=['parserator'],
     license='The MIT License: http://www.opensource.org/licenses/mit-license.php',
-    install_requires=['python-crfsuite>=0.7',
-                      'lxml',
-                      'unidecode'],
+    install_requires=reqs
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     name='parserator',
     packages=['parserator'],
     license='The MIT License: http://www.opensource.org/licenses/mit-license.php',
-    install_requires=reqs
+    install_requires=reqs,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ except ImportError :
     raise ImportError("setuptools module required, please go to https://pypi.python.org/pypi/setuptools and follow the instructions for installing setuptools")
 
 reqs = [
+    'future==0.14.3',
     'lxml==3.4.1',
     'python-crfsuite>=0.7',
     'Unidecode==0.4.17'

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,12 @@ try:
     from setuptools import setup
 except ImportError :
     raise ImportError("setuptools module required, please go to https://pypi.python.org/pypi/setuptools and follow the instructions for installing setuptools")
-from pip.req import parse_requirements
 
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements(<requirements_path>)
-
-# reqs is a list of requirement
-reqs = [str(ir.req) for ir in install_reqs]
+reqs = [
+    'lxml==3.4.1',
+    'Unidecode==0.4.17',
+    'python-crfsuite>=0.7'
+]
 
 setup(
     version='0.3',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,4 @@
 nose
-future
 caniusepython3
 coverage
 pylint

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,5 @@
+future
+caniusepython3
+coverage
+pylint
+tox

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+nose
 future
 caniusepython3
 coverage

--- a/tests/test_manual_labeling.py
+++ b/tests/test_manual_labeling.py
@@ -9,20 +9,20 @@ class TestManualsequence2XML(unittest.TestCase) :
 
         test_input = [ ('bob', 'foo') ]
         expected_xml = '<TokenSequence><foo>bob</foo></TokenSequence>'
-        assert etree.tostring( sequence2XML(test_input, 'TokenSequence') ) == expected_xml
+        assert etree.tostring( sequence2XML(test_input, 'TokenSequence') ).decode('utf-8') == expected_xml
 
     def test_two_components(self) :
 
         test_input = [ ('bob', 'foo'), ('b', 'bar') ]
         expected_xml = '<TokenSequence><foo>bob</foo> <bar>b</bar></TokenSequence>'
-        assert etree.tostring( sequence2XML(test_input, 'TokenSequence') ) == expected_xml
+        assert etree.tostring( sequence2XML(test_input, 'TokenSequence') ).decode('utf-8') == expected_xml
 
     def test_multiple_components(self) :
 
         test_input = [ ('bob', 'foo'), ('b', 'bar'), ('sr', 'foobar') ]
         expected_xml = '<TokenSequence><foo>bob</foo> <bar>b</bar> <foobar>sr</foobar></TokenSequence>'
 
-        assert etree.tostring( sequence2XML(test_input, 'TokenSequence') ) == expected_xml
+        assert etree.tostring( sequence2XML(test_input, 'TokenSequence') ).decode('utf-8') == expected_xml
 
 
 if __name__ == '__main__' :

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from parserator.data_prep_utils import sequence2XML
 from lxml import etree
 import unittest
@@ -14,9 +15,9 @@ class TestList2XML(unittest.TestCase) :
        
 def XMLequals(labeled_sequence, xml):
     correct_xml = '<TokenSequence>' + xml + '</TokenSequence>'
-    generated_xml = etree.tostring( sequence2XML(labeled_sequence, 'TokenSequence') )
-    print 'Correct:   %s' %correct_xml
-    print 'Generated: %s' %generated_xml
+    generated_xml = etree.tostring( sequence2XML(labeled_sequence, 'TokenSequence') ).decode('utf-8')
+    print('Correct:   %s' %correct_xml)
+    print('Generated: %s' %generated_xml)
     assert correct_xml == generated_xml
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34
+
+[testenv]
+commands =
+    nosetests tests
+install_command = pip install {opts} {packages}
+deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This makes this package 2.7/3.4 compatible.

Most of the required changes were to convert

```python 
print "something"
```

into

```python
print("something")
```

It also handles unicode and byte strings conversions and functions that return iterators instead of lists in python 3.4

It sets up tox for testing both 2.7 and 3.4, and has a default pylint configuration.  

I used pylint to look for other 27/34 issues.

Let me know if you want changes, I'm trying to get usaddress 3.4 compatible and this is a preq for that.