### PR TITLE
Change generator to list to allow multiple iterations while labeling

### DIFF
--- a/parserator/manual_labeling.py
+++ b/parserator/manual_labeling.py
@@ -36,7 +36,7 @@ def consoleLabel(raw_strings, labels, module):
             print('-'*50)
             print('STRING: %s' %raw_sequence)
             
-            preds = module.parse(raw_sequence)
+            preds = list(module.parse(raw_sequence))
 
             user_input = None 
             while user_input not in valid_responses :


### PR DESCRIPTION
After iterating through and printing each token in preds (which is a generator), preds is now empty. This means that if the user provides input 'n', manualTagging() is given an empty generator and so essentially does nothing except return an empty list. To fix this, I changed preds to be a list so that it can be iterated over multiple times.

Feel free to suggest/code up a different fix, I just thought that I'd point out the bug.
