### PR TITLE
got rid of ascii bunny

### DIFF
--- a/parserator/parser_template.py
+++ b/parserator/parser_template.py
@@ -17,9 +17,9 @@ from collections import OrderedDict
 #  _____________________
 # |1. CONFIGURE LABELS! |
 # |_____________________| 
-#     (\__/) || 
-#     (•ㅅ•) || 
-#     / 　 づ
+#
+#
+#
 LABELS = [] # The labels should be a list of strings
 
 #***************** OPTIONAL CONFIG ***************************************************


### PR DESCRIPTION
de-bunnified code

hey, I have had the problem with the bunny :D. During 'parserator init ...' I received exception: 

  File "*\parserator-script.py", line 9, in <module>
    load_entry_point('parserator==0.3.9', 'console_scripts', 'parserator')()
  File "*\parserator-master\parserator\main.py", line 37, in dispatch
    args.func(args)
  File "*\parserator-master\parserator\main.py", line 92, in init
    f.write(init_template())
  File "*\lib\encodings\cp1250.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u3145' in position 252: character maps to <undefined>

I am using windows-1250 that does not have the unicode character 3145 and probably cant figure out the mapping. After I removed the bunny the whole procedure worked fine :)
